### PR TITLE
Update to Scala.js 1.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,9 +100,6 @@ lazy val frontend = project
       "org.http4s" %%% "http4s-circe" % http4sVersion,
       "org.scala-js" %%% "scalajs-dom" % "2.0.0"
     ),
-    // TODO temporary workaround for https://github.com/scala-js/scala-js/issues/4601
-    Compile / fullOptJS / scalaJSLinkerConfig ~= { _.withCheckIR(false) },
-    Test / fullOptJS / scalaJSLinkerConfig ~= { _.withCheckIR(false) },
     webpack / version := "4.43.0",
     startWebpackDevServer / version := "3.11.0",
     webpackResources := baseDirectory.value / "webpack" * "*",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.7.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.8.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.20.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")


### PR DESCRIPTION
And revert the temporary workaround.